### PR TITLE
Add support for Slack Apps in addition to webhook URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ If you want to learn more, please consult this [tutorial on how pull requests wo
 Here's an overview of how you can make a pull request against this project:
 
 1. Fork the [Slack Alerts GitHub repository](https://github.com/splunk/slack-alerts)
-2. Clone your fork using git and create a branch off master
+2. Clone your fork using git and create a branch off `main`
 3. Run all the tests to verify your environment
 4. Make your changes, commit and push once your tests have passed
 5. Submit a pull request through the GitHub website using the changes from your forked codebase

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splunk-slack-alerts",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Slack alert action for Splunk Enterprise",
   "private": true,
   "splunk": {

--- a/src/app/README.md
+++ b/src/app/README.md
@@ -14,10 +14,23 @@ App installation requires admin privileges.
 
 In order to setup the app, navigate to "Settings" -> "Alert actions". Click on "Setup Slack Alerts".
 
+On the setup screen, you'll need to supply a Slack App OAuth token. To set up a new Slack App for your
+workspace, follow the instructions on https://api.slack.com/apps.
+
+Once you have the Slack App created, you **must** give the app permission to the `chat:write` and
+`chat:write.public` OAuth scopes in your Slack workspace. These scopes allow your app to write messages
+to every public channel and user in your workspace. The app will also be able to write to any private
+channel that it is added to.
+
+#### Deprecated configuration option
+
+> This alert action was originally built using the Slack Webhook URL functionality. Slack has recently
+> deprecated this feature in favor of the Slack App method above. **Webhook URL support may be
+> removed in a future release of Slack.** For more information see
+> https://slack.com/apps/A0F7XDUAZ-incoming-webhooks
+
 On the setup screen you'll want to supply a Webhook URL. You can obtain this URL by configuring a
 custom integration for you Slack workspace.
-
-For more information see https://slack.com/apps/A0F7XDUAZ-incoming-webhooks
 
 ## Troubleshooting
 

--- a/src/app/README/alert_actions.conf.spec
+++ b/src/app/README/alert_actions.conf.spec
@@ -1,13 +1,22 @@
 [slack]
 
+param.slack_app_oauth_token = <string>
+* The Slack App OAuth token that Splunk should use to send Slack alerts.  This
+* can be obtained by create a new Slack App for your workspace at
+* https://api.slack.com/apps.
+* This takes precendence over the deprecated webhook_url parameter (below).
+
 param.webhook_url = <string>
+* DEPRECATED - Slack has deprecated this feature and will possibly be removed in the future.
 * The webhook URL to send the Slack message requests to. This can be obtained
 * by creating a new "Incoming webhook" integration in Slack.
 
 param.from_user = <string>
+* DEPRECATED - This is only used in the deprecated webhook_url parameter.
 * The name of the user sending the Slack message. By default this is "Splunk".
 
 param.from_user_icon = <string>
+* DEPRECATED - This is only used in the deprecated webhook_url parameter.
 * URL to an icon to show as the avatar for the Slack message. By default this is
 * a Splunk icon.
 

--- a/src/app/README/savedsearches.conf.spec
+++ b/src/app/README/savedsearches.conf.spec
@@ -20,6 +20,10 @@ action.slack.param.fields = <csv-list>
 * It is possible to use wildcards, such as "*" for all fields or "foo*" for 
 * prefixed fields, etc.
 
+action.slack.param.slack_app_oauth_token_override = <string>
+* Override the Slack App OAuth token for a single alert. This useful when wanting
+* to send some alerts to different Slack teams.
+
 action.slack.param.webhook_url_override = <string>
 * Override the Slack webhook URL for a single alert. This useful when wanting
 * to send some alerts to different Slack teams.

--- a/src/app/default/alert_actions.slap.conf
+++ b/src/app/default/alert_actions.slap.conf
@@ -5,6 +5,7 @@ description = Send a message to a Slack channel
 icon_path = slack.png
 python.version = python3
 payload_format = json
+param.slack_app_oauth_token =<@= process.env.NODE_ENV !== 'production' && process.env.SLACK_APP_OAUTH_TOKEN ? " " + process.env.SLACK_APP_OAUTH_TOKEN : "" @>
 param.webhook_url =<@= process.env.NODE_ENV !== 'production' && process.env.SLACK_WEBHOOK_URL ? " " + process.env.SLACK_WEBHOOK_URL : "" @>
 param.from_user = Splunk
 param.from_user_icon = https://s3-us-west-1.amazonaws.com/ziegfried-apps/slack-alerts/splunk-icon.png

--- a/src/app/default/data/ui/alerts/slack.html
+++ b/src/app/default/data/ui/alerts/slack.html
@@ -46,6 +46,18 @@
     <br clear="both" />
     <div style="clear: both; color: #888; margin: 25px 0 10px 0;">Advanced settings:</div>
     <div style="clear: both" class="control-group">
+        <label class="control-label" for="slack_app_token_override">Slack App OAuth Token</label>
+
+        <div class="controls">
+            <input type="text" name="action.slack.param.slack_app_oauth_token_override" id="slack_fields" placeholder="Optional" />
+            <span class="help-block">
+                You can override the <a href="https://api.slack.com/apps" target="_blank" noreferer>Slack App OAuth Token</a> here
+                if you need to send the alert message to a different Slack team.
+            </span>
+        </div>
+    </div>
+    <br clear="both" />
+    <div style="clear: both" class="control-group">
         <label class="control-label" for="slack_url_override">Webhook URL</label>
 
         <div class="controls">

--- a/src/ui/pages/slack_alerts_setup/api.js
+++ b/src/ui/pages/slack_alerts_setup/api.js
@@ -13,6 +13,7 @@ export function loadAlertActionConfig() {
         .then((data) => {
             const d = data.entry[0].content;
             return {
+                slack_app_oauth_token: d['param.slack_app_oauth_token'],
                 webhook_url: d['param.webhook_url'],
                 from_user: d['param.from_user'],
                 from_user_icon: d['param.from_user_icon'],
@@ -26,6 +27,7 @@ export function updateAlertActionConfig(data) {
         {
             method: 'POST',
             body: [
+                `param.slack_app_oauth_token=${encodeURIComponent(data.slack_app_oauth_token)}`,
                 `param.webhook_url=${encodeURIComponent(data.webhook_url)}`,
                 `param.from_user=${encodeURIComponent(data.from_user)}`,
                 `param.from_user_icon=${encodeURIComponent(data.from_user_icon)}`,

--- a/src/ui/pages/slack_alerts_setup/form.jsx
+++ b/src/ui/pages/slack_alerts_setup/form.jsx
@@ -49,8 +49,11 @@ settings:
                 <TabLayout.Panel label="Slack App OAuth Token (preferred)" panelId="oauth" style={{ margin: 20 }}>
                     <Paragraph>
                         The Slack App OAuth token is the preferred method for using the Slack alert action.
-                        The webhook url method (in the second tab) is deprecated and may be removed in a future release
-                        of Slack.
+                        The webhook url method (in the second tab) is {' '}
+                        <Link to="https://slack.com/apps/A0F7XDUAZ-incoming-webhooks" openInNewContext>
+                            deprecated
+                        </Link>{' '}
+                        and may be removed in a future release of Slack.
                     </Paragraph>
                     <Heading level={3}>Slack App OAuth Token</Heading>
                     <Paragraph>
@@ -112,7 +115,7 @@ settings:
                     </Paragraph>
                     <Heading level={3}>Slack Incoming Webhook</Heading>
                     <Paragraph>
-                        This alert action uses Slack's{' '}
+                        This alert action uses Slack's deprecated{' '}
                         <Link to="https://slack.com/apps/A0F7XDUAZ-incoming-webhooks" openInNewContext>
                             Incoming Webhooks
                         </Link>{' '}

--- a/src/ui/pages/slack_alerts_setup/form.jsx
+++ b/src/ui/pages/slack_alerts_setup/form.jsx
@@ -1,8 +1,11 @@
 import Button from '@splunk/react-ui/Button';
+import Code from '@splunk/react-ui/Code';
+import CollapsiblePanel from '@splunk/react-ui/CollapsiblePanel';
 import ControlGroup from '@splunk/react-ui/ControlGroup';
 import Heading from '@splunk/react-ui/Heading';
 import Link from '@splunk/react-ui/Link';
 import Paragraph from '@splunk/react-ui/Paragraph';
+import TabLayout from '@splunk/react-ui/TabLayout';
 import Text from '@splunk/react-ui/Text';
 import React, { useCallback } from 'react';
 import { useSlackConfig, redirectToAlertListingPage } from './config';
@@ -22,113 +25,154 @@ export function SetupForm() {
     const fromUserName = loading ? '' : data.from_user;
     const fromUserIcon = loading ? '' : data.from_user_icon;
 
+    const oauth_app_manifest = `
+display_information:
+  name: Splunk Alerts
+features:
+  bot_user:
+    display_name: Splunk
+    always_online: false
+oauth_config:
+  scopes:
+    bot:
+      - chat:write
+      - chat:write.public
+      - chat:write.customize
+settings:
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false`.trim();
+
     return (
         <>
-            <Heading level={2}>Preferred Alerting Method</Heading>
-            <Paragraph>
-                The Slack App OAuth token is the preferred method for using the Slack alert action.
-                The webhook url method (below) is deprecated and may be removed in a future release
-                of Slack.
-            </Paragraph>
-            <Heading level={3}>Slack App OAuth Token</Heading>
-            <Paragraph>
-                This alert action uses{' '}
-                <Link to="https://api.slack.com/apps" openInNewContext>
-                    custom Slack Apps
-                </Link>{' '}
-                to post messages from Splunk into Slack channels. You can set a default Slack App OAuth
-                token here, which will be used for all alerts by default. Each alert can override and
-                use a different Slack App OAuth Token that has different permissions or can send to a
-                different Slack workspace.
-            </Paragraph>
-            <FormWrapper>
-                <ControlGroup
-                    label="Slack App OAuth Token"
-                    help={
+
+            <TabLayout defaultActivePanelId="oauth">
+                <TabLayout.Panel label="Slack App OAuth Token (preferred)" panelId="oauth" style={{ margin: 20 }}>
+                    <Paragraph>
+                        The Slack App OAuth token is the preferred method for using the Slack alert action.
+                        The webhook url method (in the second tab) is deprecated and may be removed in a future release
+                        of Slack.
+                    </Paragraph>
+                    <Heading level={3}>Slack App OAuth Token</Heading>
+                    <Paragraph>
+                        This alert action uses{' '}
                         <Link to="https://api.slack.com/apps" openInNewContext>
-                            Configure Slack App OAuth token
-                        </Link>
-                    }
-                >
-                    <Text
-                        value={slackAppOauthToken}
-                        onChange={updateOauthToken}
-                        disabled={loading}
-                        placeholder="xoxb-111111111111-2222222222222-abcdefghijklmnopqrstuvwx"
-                    />
-                </ControlGroup>
-            </FormWrapper>
-
-
-
-            <Heading level={2}>Deprecated Alerting Method</Heading>
-            <Paragraph>
-                Slack has deprecated the "Incoming Webhooks" feature in favor of using{' '}
-                <Link to="https://api.slack.com/apps" openInNewContext>
-                    Slack Apps
-                </Link>.{' '}
-                Slack may remove the incoming webhook feature in a future update. If you provide both a
-                "Slack App OAuth Token" and an "Incoming Webhook", then the "Slack App OAuth Token" will
-                take precedence. You can still override the OAuth token by using the "webhook_url_override"
-                parameter on an individual alert.
-            </Paragraph>
-            <Heading level={3}>Slack Incoming Webhook</Heading>
-            <Paragraph>
-                This alert action uses Slack's{' '}
-                <Link to="https://slack.com/apps/A0F7XDUAZ-incoming-webhooks" openInNewContext>
-                    Incoming Webhooks
-                </Link>{' '}
-                to post messages from Splunk into Slack channels. You can set a default webhook URL here,
-                which will be used for all alerts by default. Each alert can override and use a different
-                webhook URL that has different permissions or can send to a different Slack workspace.
-            </Paragraph>
-            <FormWrapper>
-                <ControlGroup
-                    label="Webhook URL"
-                    help={
+                            custom Slack Apps
+                        </Link>{' '}
+                        to post messages from Splunk into Slack channels. You can set a default Slack App OAuth
+                        token here, which will be used for all alerts by default. Each alert can override and
+                        use a different Slack App OAuth Token that has different permissions or can send to a
+                        different Slack workspace.
+                    </Paragraph>
+                    <Paragraph>
+                        Once you have the Slack App created, you <b>must</b> give the app permission to the{' '}
+                        <code>chat:write</code>, <code>chat:write.public</code>, and <code>chat:write.customize</code>{' '}
+                        OAuth scopes in your Slack workspace. You can grant these permissions in the "OAuth &amp;
+                        Permissions" tab at the link above.
+                    </Paragraph>
+                    <Paragraph>
+                        These scopes allow your app to write messages to every public channel and user in
+                        your workspace. The app will also be able to write to any private channel, but it
+                        will need to be explicitly granted access to each private channel.
+                    </Paragraph>
+                    <CollapsiblePanel title="Setting OAuth scopes using an app manifest">
+                        <Paragraph style={{ margin: 20 }}>
+                            Slack also lets you set OAuth scopes using the "App Manifest" tab. The code below
+                            can be pasted into the App Manifest YAML input box to set all of the permissions above.
+                        </Paragraph>
+                        <Code  style={{ margin: 20 }} value={oauth_app_manifest} />
+                    </CollapsiblePanel>
+                    <FormWrapper>
+                        <ControlGroup
+                            label="Slack App OAuth Token"
+                            help={
+                                <Link to="https://api.slack.com/apps" openInNewContext>
+                                    Configure Slack App OAuth token
+                                </Link>
+                            }
+                        >
+                            <Text
+                                value={slackAppOauthToken}
+                                onChange={updateOauthToken}
+                                disabled={loading}
+                                placeholder="xoxb-111111111111-2222222222222-abcdefghijklmnopqrstuvwx"
+                            />
+                        </ControlGroup>
+                    </FormWrapper>
+                </TabLayout.Panel>
+                <TabLayout.Panel label="Slack Incoming Webhook (deprecated)" panelId="webhook" style={{ margin: 20 }}>
+                    <Paragraph>
+                        Slack has deprecated the "Incoming Webhooks" feature in favor of using{' '}
+                        <Link to="https://api.slack.com/apps" openInNewContext>
+                            Slack Apps
+                        </Link>.{' '}
+                        Slack may remove the incoming webhook feature in a future update. If you provide both a
+                        "Slack App OAuth Token" and an "Incoming Webhook", then the "Slack App OAuth Token" will
+                        take precedence. You can still override the OAuth token by using the "webhook_url_override"
+                        parameter on an individual alert.
+                    </Paragraph>
+                    <Heading level={3}>Slack Incoming Webhook</Heading>
+                    <Paragraph>
+                        This alert action uses Slack's{' '}
                         <Link to="https://slack.com/apps/A0F7XDUAZ-incoming-webhooks" openInNewContext>
-                            Configure Slack incoming webhook
-                        </Link>
-                    }
-                >
-                    <Text
-                        value={webhookUrl}
-                        onChange={updateUrl}
-                        disabled={loading}
-                        placeholder="https://hooks.slack.com/services/XXXXX/YYYY/ZZZZZ"
-                    />
-                </ControlGroup>
-            </FormWrapper>
-            <Heading level={3}>Message Appearance</Heading>
-            <Paragraph>
-                The following settings will influence how messages will show up in Slack.{' '}
-                <Link onClick={() => openSlackMessagePreview(data)} openInNewContext>
-                    Show Preview
-                </Link>
-                .
-            </Paragraph>
-            <FormWrapper>
-                <ControlGroup
-                    label="Sender Name"
-                    help="This name will appear in slack as the user sending the message."
-                >
-                    <Text value={fromUserName} onChange={updateUser} disabled={loading} />
-                </ControlGroup>
-                <ControlGroup
-                    label="Sender Icon"
-                    help="The avatar/icon shown by the sender of the slack message. This URL needs to be accessible from the internet."
-                >
-                    <Text value={fromUserIcon} onChange={updateUserIcon} disabled={loading} />
-                </ControlGroup>
-            </FormWrapper>
-            <ButtonGroup>
-                <div>
-                    <Button label="Cancel" appearance="secondary" onClick={redirectToAlertListingPage} />
-                </div>
-                <div>
-                    <Button label="Save" appearance="primary" disabled={loading || !isDirty} onClick={save} />
-                </div>
-            </ButtonGroup>
+                            Incoming Webhooks
+                        </Link>{' '}
+                        to post messages from Splunk into Slack channels. You can set a default webhook URL here,
+                        which will be used for all alerts by default. Each alert can override and use a different
+                        webhook URL that has different permissions or can send to a different Slack workspace.
+                    </Paragraph>
+                    <FormWrapper>
+                        <ControlGroup
+                            label="Webhook URL"
+                            help={
+                                <Link to="https://slack.com/apps/A0F7XDUAZ-incoming-webhooks" openInNewContext>
+                                    Configure Slack incoming webhook
+                                </Link>
+                            }
+                        >
+                            <Text
+                                value={webhookUrl}
+                                onChange={updateUrl}
+                                disabled={loading}
+                                placeholder="https://hooks.slack.com/services/XXXXX/YYYY/ZZZZZ"
+                            />
+                        </ControlGroup>
+                    </FormWrapper>
+                </TabLayout.Panel>
+            </TabLayout>
+
+            <div style={{ margin: 20 }}>
+                <Heading level={3}>Message Appearance</Heading>
+                <Paragraph>
+                    The following settings will influence how messages will show up in Slack.{' '}
+                    <Link onClick={() => openSlackMessagePreview(data)} openInNewContext>
+                        Show Preview
+                    </Link>
+                    .
+                </Paragraph>
+                <FormWrapper>
+                    <ControlGroup
+                        label="Sender Name"
+                        help="This name will appear in slack as the user sending the message."
+                    >
+                        <Text value={fromUserName} onChange={updateUser} disabled={loading} />
+                    </ControlGroup>
+                    <ControlGroup
+                        label="Sender Icon"
+                        help="The avatar/icon shown by the sender of the slack message. This URL needs to be accessible from the internet."
+                    >
+                        <Text value={fromUserIcon} onChange={updateUserIcon} disabled={loading} />
+                    </ControlGroup>
+                </FormWrapper>
+                <ButtonGroup>
+                    <div>
+                        <Button label="Cancel" appearance="secondary" onClick={redirectToAlertListingPage} />
+                    </div>
+                    <div>
+                        <Button label="Save" appearance="primary" disabled={loading || !isDirty} onClick={save} />
+                    </div>
+                </ButtonGroup>
+            </div>
         </>
     );
 }

--- a/src/ui/pages/slack_alerts_setup/form.jsx
+++ b/src/ui/pages/slack_alerts_setup/form.jsx
@@ -12,16 +12,66 @@ import { ButtonGroup, FormWrapper } from './styles';
 export function SetupForm() {
     const [{ loading, error, data, isDirty }, update, save] = useSlackConfig();
 
+    const updateOauthToken = useCallback((e, { value }) => update({ ...data, slack_app_oauth_token: value }));
     const updateUrl = useCallback((e, { value }) => update({ ...data, webhook_url: value }));
     const updateUser = useCallback((e, { value }) => update({ ...data, from_user: value }));
     const updateUserIcon = useCallback((e, { value }) => update({ ...data, from_user_icon: value }));
 
+    const slackAppOauthToken = loading ? '' : data.slack_app_oauth_token;
     const webhookUrl = loading ? '' : data.webhook_url;
     const fromUserName = loading ? '' : data.from_user;
     const fromUserIcon = loading ? '' : data.from_user_icon;
 
     return (
         <>
+            <Heading level={2}>Preferred Alerting Method</Heading>
+            <Paragraph>
+                The Slack App OAuth token is the preferred method for using the Slack alert action.
+                The webhook url method (below) is deprecated and may be removed in a future release
+                of Slack.
+            </Paragraph>
+            <Heading level={3}>Slack App OAuth Token</Heading>
+            <Paragraph>
+                This alert action uses{' '}
+                <Link to="https://api.slack.com/apps" openInNewContext>
+                    custom Slack Apps
+                </Link>{' '}
+                to post messages from Splunk into Slack channels. You can set a default Slack App OAuth
+                token here, which will be used for all alerts by default. Each alert can override and
+                use a different Slack App OAuth Token that has different permissions or can send to a
+                different Slack workspace.
+            </Paragraph>
+            <FormWrapper>
+                <ControlGroup
+                    label="Slack App OAuth Token"
+                    help={
+                        <Link to="https://api.slack.com/apps" openInNewContext>
+                            Configure Slack App OAuth token
+                        </Link>
+                    }
+                >
+                    <Text
+                        value={slackAppOauthToken}
+                        onChange={updateOauthToken}
+                        disabled={loading}
+                        placeholder="xoxb-111111111111-2222222222222-abcdefghijklmnopqrstuvwx"
+                    />
+                </ControlGroup>
+            </FormWrapper>
+
+
+
+            <Heading level={2}>Deprecated Alerting Method</Heading>
+            <Paragraph>
+                Slack has deprecated the "Incoming Webhooks" feature in favor of using{' '}
+                <Link to="https://api.slack.com/apps" openInNewContext>
+                    Slack Apps
+                </Link>.{' '}
+                Slack may remove the incoming webhook feature in a future update. If you provide both a
+                "Slack App OAuth Token" and an "Incoming Webhook", then the "Slack App OAuth Token" will
+                take precedence. You can still override the OAuth token by using the "webhook_url_override"
+                parameter on an individual alert.
+            </Paragraph>
             <Heading level={3}>Slack Incoming Webhook</Heading>
             <Paragraph>
                 This alert action uses Slack's{' '}
@@ -29,7 +79,7 @@ export function SetupForm() {
                     Incoming Webhooks
                 </Link>{' '}
                 to post messages from Splunk into Slack channels. You can set a default webhook URL here,
-                which will be used for all alerts be default. Each alert can override and use a different
+                which will be used for all alerts by default. Each alert can override and use a different
                 webhook URL that has different permissions or can send to a different Slack workspace.
             </Paragraph>
             <FormWrapper>


### PR DESCRIPTION
This is a PR to support Slack Apps as mentioned in issue #25.

Slack has deprecated the "Incoming Webhooks" feature and is now encouraging everyone to switch to using Slack apps instead. Details are mentioned in the description here: https://slack.com/apps/A0F7XDUAZ-incoming-webhooks.

I have updated the logic to now support both Slack Apps and webhook URLs. If both a Slack App OAuth token and a webhook URL are provided, then the logic will bias towards using the OAuth token.

I also updated the READMEs and Splunk configuration files to call out that Slack has deprecated webhook URLs.

I have tested this functionality on my local Splunk instance to confirm it works for all combinations of supplying a Slack App OAuth token, webhook URL, OAuth token override, or webhook URL override.

Finally, when making my updates, I also made a minor change to the CONTRIBUTING.md file to reference that `main` is the new default branch.


I believe I have completed all the steps in CONTRIBUTING.md (including filling out the Splunk contributions form), but please let me know if there is anything else you need from me.