### PR TITLE
Potential fix for #31 - define 'res' as empty list, when it's not being created due to empty SPL search results

### DIFF
--- a/src/app/bin/slack.py
+++ b/src/app/bin/slack.py
@@ -24,6 +24,8 @@ def log(msg, *args):
 
 def build_fields_attachment(payload):
     res = payload.get('result', dict())
+    if not res:
+        res={}
     available_fields = list(res.keys())
     field_attachments = []
     seen_fields = set()


### PR DESCRIPTION
Potential fix for #31 - define 'res' as empty list, when it's not being created due to empty SPL search results:
slack_alerts/bin:
```
(...)
def build_fields_attachment(payload):  
    res = payload.get('result', dict())                                        
    if not res:                                                                
       res = {}                                                  
    available_fields = list(res.keys()) 
(...)
```

It addresses the problem in my test environment in context of the issue #31 and I observed no impact on the behavior & additional for other sample alerts and how they're performed. Yet, please perform any additional tests when needed (I have no dev background & experience).