### PR TITLE
Omit username and icon_url fields from request JSON if they are empty

### DIFF
--- a/src/app/bin/slack.py
+++ b/src/app/bin/slack.py
@@ -82,8 +82,10 @@ def build_slack_message(payload):
 
     if config['attachment'] != 'message':
         params['text'] = format_template('message', payload)
-    params['username'] = config.get('from_user', 'Splunk')
-    params['icon_url'] = config.get('from_user_icon')
+    if config.get('from_user'):
+        params['username'] = config.get('from_user')
+    if config.get('from_user_icon'):
+        params['icon_url'] = config.get('from_user_icon')
 
     channel = config.get('channel')
     if channel:


### PR DESCRIPTION
This is to support keyword alerts in Slack (see #42)

I think I went through all the contribution steps, but let me know if anything is missing! Thanks.