### PR TITLE
Update default.meta to define global write access

### DIFF
--- a/src/app/metadata/default.meta
+++ b/src/app/metadata/default.meta
@@ -1,2 +1,3 @@
 []
 export = system
+access = read : [ * ], write : [ admin, power ]


### PR DESCRIPTION
This app is currently failing AppInspect, as the latest version requires global write access to be defined in default.meta. 

Splunk's [documentation](https://docs.splunk.com/Documentation/Splunk/latest/admin/Defaultmetaconf) recommends a default stanza of `access = read : [ * ], write : [ admin, power ]`